### PR TITLE
1200bps tape interface

### DIFF
--- a/ROM/src/io_card.s
+++ b/ROM/src/io_card.s
@@ -4,6 +4,7 @@
 .include "asminc/slot_defs.inc"
 
 TIMER_COUNT = 15625     ; 64 ticks per second with a 1 MHz clock
+CSPEED_DEFAULT = $A3    ; 600bps delay
 
 .export IO_VIA_START    = SLOT0
 .export IO_VIA_PORTB    = IO_VIA_START + $00
@@ -41,6 +42,10 @@ TIMER_COUNT = 15625     ; 64 ticks per second with a 1 MHz clock
 .export IO_IER_TIMER1  = %01000000
 
 .export IO_PCR_CA2_HANDSHAKE    = %00001000
+
+.segment "ZEROPAGE"
+
+CSPEED: .res 1
 
 .segment "SD_WORK"
 
@@ -145,6 +150,8 @@ BYTE_AVAIL:
 
 .proc   CLOAD
         sei
+        lda     #CSPEED_DEFAULT         ; set default casette speed
+        sta     CSPEED
         lda     #$0A
         jsr     COUT
         lda     #<MSG_PRESS_PLAY        ; display press play message
@@ -220,6 +227,12 @@ get_addr:
         adc     CRC
         sta     CRC
 
+get_cspeed:
+        jsr     CGETBYTE                ; get speed & push to stack
+        pha
+        clc
+        adc     CRC
+        sta     CRC
 checksum:
         jsr     CGETBYTE                ; get and validate the checksum
         cmp     CRC
@@ -236,9 +249,12 @@ header_checksum_bad:
         lda     #>MSG_CHECKSUM_FAIL
         sta     MSGH
         jsr     SHWMSG
+        pla                             ; pull CSPEED from stack so RTS works
         rts
 
 header_end:
+        pla                             ; pull CSPEED from stack and set it
+        sta     CSPEED
         jsr     SHWMSG                  ; output the details from the header
         lda     #<LOAD_PAGE             ; file name
         sta     MSGL
@@ -318,6 +334,9 @@ end:
 
 .proc CSAVE
         sei
+        lda     #CSPEED_DEFAULT         ; set default speed
+        sta     CSPEED
+
         lda     IO_VIA_PORTB            ; ensure TX is high
         ora     #IO_MASK_CAS_TX
         sta     IO_VIA_PORTB
@@ -390,6 +409,13 @@ store_addr:
         sta     CRC
 
         lda     H
+        jsr     CPUTBYTE
+        clc
+        adc     CRC
+        sta     CRC
+
+store_cspeed:
+        lda     CSPEED
         jsr     CPUTBYTE
         clc
         adc     CRC
@@ -522,7 +548,7 @@ CHALFWAIT:                      ; half the waiting time
         phy                     ; save Y
         nop
         nop
-        ldy     #$4D            ; 77 x 5us
+        ldy     CSPEED
 CWAIT1:
         dey
         bne     CWAIT1
@@ -542,7 +568,7 @@ CWAIT1:
         sta     IO_VIA_PORTB
         pla
 loop1:                          ; outer loop - 1/10th of second
-        ldx     #$78            ; 120 byte-periods
+        ldx     #$3C            ; 60 byte-periods
 
 loop2:                          ; inner loop - 1 byte period
         jsr     CWAIT

--- a/docs/cassette_format.txt
+++ b/docs/cassette_format.txt
@@ -2,11 +2,12 @@ Compé6502 Cassette format
 
 5 seconds leader
 
-header:
+header - always recorded at 600bps
 	synchronization bytes: 0x09 0x08 0x07 0x06 0x05 0x04 0x03 0x02 0x01 0x00
 	file name: 8 bytes, padded with 0x00
 	start address: two bytes, low byte first
 	end address+1: two bytes, low byte first
+	speed: one byte, 0xA3 for 600bps or 0x4D for 1200bps
 	header checksum (including sync)
 	
 1 second leader

--- a/util/bin2tape.py
+++ b/util/bin2tape.py
@@ -7,9 +7,9 @@ high_val = round(128 + (128 * intensity))
 
 SAMPLE_RATE = 9600
 SPACE_FREQ = 1200
-SPACE_CYCLES = 2
+SPACE_CYCLES = 1
 MARK_FREQ = 2400
-MARK_CYCLES = 4
+MARK_CYCLES = 2
 
 
 def generate_cycle(frequency: int) -> bytearray:


### PR DESCRIPTION
Speed (600 or 1200bps) is specified in header. Save routine always uses 600bps, but bin2tape.py can generate either as desired.

Closes #31.